### PR TITLE
fix: build Content-Disposition with HeaderUtils to prevent header injection

### DIFF
--- a/src/Macros/Response/Filename.php
+++ b/src/Macros/Response/Filename.php
@@ -4,13 +4,22 @@ namespace audunru\ExportResponse\Macros\Response;
 
 use audunru\ExportResponse\Response\StreamedResponse;
 use Illuminate\Http\Response;
+use Illuminate\Support\Str;
+use Symfony\Component\HttpFoundation\HeaderUtils;
 
 class Filename
 {
     public function __invoke()
     {
         return function (string $filename, ?string $filenameStar = null): Response|StreamedResponse {
-            $this->headers->set('Content-Disposition', sprintf('attachment; filename="%s"; filename*=utf-8\'\'%s', $filename, urlencode($filenameStar ?? $filename)));
+            $name = $filenameStar ?? $filename;
+            $fallback = $filenameStar !== null ? $filename : Str::ascii($filename);
+
+            $this->headers->set('Content-Disposition', HeaderUtils::makeDisposition(
+                HeaderUtils::DISPOSITION_ATTACHMENT,
+                $name,
+                $fallback
+            ));
 
             return $this;
         };

--- a/tests/Feature/CsvTest.php
+++ b/tests/Feature/CsvTest.php
@@ -14,7 +14,7 @@ class CsvTest extends TestCase
             ->assertOk()
             ->assertHeader('Content-Type', 'text/csv; charset=utf-8');
 
-        $this->assertEquals("attachment; filename=\"documents.csv\"; filename*=utf-8''documents.csv", $response->headers->get('Content-Disposition'));
+        $this->assertEquals('attachment; filename=documents.csv', $response->headers->get('Content-Disposition'));
         $this->assertEquals('id,name,data.foo,meta,data.bar
 1,Navn,bar,,
 2,"Noe annet",bar,,foo
@@ -29,7 +29,7 @@ class CsvTest extends TestCase
             ->assertOk()
             ->assertHeader('Content-Type', 'text/csv; charset=utf-8');
 
-        $this->assertEquals("attachment; filename=\"documents.csv\"; filename*=utf-8''documents.csv", $response->headers->get('Content-Disposition'));
+        $this->assertEquals('attachment; filename=documents.csv', $response->headers->get('Content-Disposition'));
         $this->assertEquals('id,name,data.foo,meta,data.bar
 1,Navn,bar,,
 2,"Noe annet",bar,,foo
@@ -44,7 +44,7 @@ class CsvTest extends TestCase
             ->assertOk()
             ->assertHeader('Content-Type', 'text/csv; charset=utf-8');
 
-        $this->assertEquals("attachment; filename=\"lazy.csv\"; filename*=utf-8''lazy.csv", $response->headers->get('Content-Disposition'));
+        $this->assertEquals('attachment; filename=lazy.csv', $response->headers->get('Content-Disposition'));
         $content = array_filter(explode("\n", $response->streamedContent()));
         $this->assertEquals(1001, count($content));
         $this->assertEquals('id,name,data.foo,meta', $content[0]);

--- a/tests/Feature/XlsxTest.php
+++ b/tests/Feature/XlsxTest.php
@@ -14,7 +14,7 @@ class XlsxTest extends TestCase
             ->assertOk()
             ->assertHeader('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
 
-        $this->assertEquals("attachment; filename=\"documents.xlsx\"; filename*=utf-8''documents.xlsx", $response->headers->get('Content-Disposition'));
+        $this->assertEquals('attachment; filename=documents.xlsx', $response->headers->get('Content-Disposition'));
 
         $reader = $this->getExcelReader($response->streamedContent());
         $headers = $reader->getHeaders();
@@ -46,7 +46,7 @@ class XlsxTest extends TestCase
             ->assertOk()
             ->assertHeader('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
 
-        $this->assertEquals("attachment; filename=\"documents.xlsx\"; filename*=utf-8''documents.xlsx", $response->headers->get('Content-Disposition'));
+        $this->assertEquals('attachment; filename=documents.xlsx', $response->headers->get('Content-Disposition'));
 
         $reader = $this->getExcelReader($response->streamedContent());
         $headers = $reader->getHeaders();
@@ -78,7 +78,7 @@ class XlsxTest extends TestCase
             ->assertOk()
             ->assertHeader('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
 
-        $this->assertEquals("attachment; filename=\"lazy.xlsx\"; filename*=utf-8''lazy.xlsx", $response->headers->get('Content-Disposition'));
+        $this->assertEquals('attachment; filename=lazy.xlsx', $response->headers->get('Content-Disposition'));
         $reader = $this->getExcelReader($response->streamedContent());
         $headers = $reader->getHeaders();
         $rows = $reader->getRows()->toArray();

--- a/tests/Feature/XmlTest.php
+++ b/tests/Feature/XmlTest.php
@@ -14,7 +14,7 @@ class XmlTest extends TestCase
             ->assertOk()
             ->assertHeader('Content-Type', 'application/xml');
 
-        $this->assertEquals("attachment; filename=\"documents.xml\"; filename*=utf-8''documents.xml", $response->headers->get('Content-Disposition'));
+        $this->assertEquals('attachment; filename=documents.xml', $response->headers->get('Content-Disposition'));
         $this->assertEquals('<?xml version="1.0"?>
 <root><data><id>1</id><name>Navn</name><data><foo>bar</foo></data><meta/></data><data><id>2</id><name>Noe annet</name><data><foo>bar</foo><bar>foo</bar></data></data><meta><page>1</page></meta></root>
 ', $response->getContent());

--- a/tests/Unit/FilenameTest.php
+++ b/tests/Unit/FilenameTest.php
@@ -15,7 +15,7 @@ class FilenameTest extends TestCase
         $response = new Response;
         $response->filename('filename.csv');
 
-        $this->assertEquals("attachment; filename=\"filename.csv\"; filename*=utf-8''filename.csv", $response->headers->get('Content-Disposition'));
+        $this->assertEquals('attachment; filename=filename.csv', $response->headers->get('Content-Disposition'));
     }
 
     public function test_it_adds_content_disposition_header_with_non_ascii_characters()
@@ -25,6 +25,29 @@ class FilenameTest extends TestCase
         $response = new Response;
         $response->filename('AEOEAA.csv', 'ÆØÅ.csv');
 
-        $this->assertEquals("attachment; filename=\"AEOEAA.csv\"; filename*=utf-8''%C3%86%C3%98%C3%85.csv", $response->headers->get('Content-Disposition'));
+        $this->assertEquals("attachment; filename=AEOEAA.csv; filename*=utf-8''%C3%86%C3%98%C3%85.csv", $response->headers->get('Content-Disposition'));
+    }
+
+    public function test_it_derives_ascii_fallback_for_single_non_ascii_filename()
+    {
+        Response::macro('filename', app(Filename::class)());
+
+        $response = new Response;
+        $response->filename('ÆØÅ.csv');
+
+        $this->assertEquals("attachment; filename=AEOA.csv; filename*=utf-8''%C3%86%C3%98%C3%85.csv", $response->headers->get('Content-Disposition'));
+    }
+
+    public function test_it_neutralizes_double_quote_injection_in_filename()
+    {
+        Response::macro('filename', app(Filename::class)());
+
+        $response = new Response;
+        $response->filename('a"b.csv');
+
+        $header = $response->headers->get('Content-Disposition');
+        $this->assertEquals('attachment; filename="a\"b.csv"', $header);
+        $this->assertStringNotContainsString("\r", $header);
+        $this->assertStringNotContainsString("\n", $header);
     }
 }

--- a/tests/Unit/JsonResponseToCsvTest.php
+++ b/tests/Unit/JsonResponseToCsvTest.php
@@ -15,7 +15,7 @@ class JsonResponseToCsvTest extends TestCase
 
         $response = new TestResponse($this->getUnwrappedResponse()->toCsv('filename.csv'));
 
-        $this->assertEquals("attachment; filename=\"filename.csv\"; filename*=utf-8''filename.csv", $response->headers->get('Content-Disposition'));
+        $this->assertEquals('attachment; filename=filename.csv', $response->headers->get('Content-Disposition'));
         $this->assertEquals('id,name,data.foo,meta,data.bar
 1,Navn,bar,,
 2,"Noe annet",bar,,foo
@@ -28,7 +28,7 @@ class JsonResponseToCsvTest extends TestCase
 
         $response = new TestResponse($this->getWrappedResponse()->toCsv('filename.csv', 'data'));
 
-        $this->assertEquals("attachment; filename=\"filename.csv\"; filename*=utf-8''filename.csv", $response->headers->get('Content-Disposition'));
+        $this->assertEquals('attachment; filename=filename.csv', $response->headers->get('Content-Disposition'));
         $this->assertEquals('id,name,data.foo,meta,data.bar
 1,Navn,bar,,
 2,"Noe annet",bar,,foo

--- a/tests/Unit/JsonResponseToXlsxTest.php
+++ b/tests/Unit/JsonResponseToXlsxTest.php
@@ -15,7 +15,7 @@ class JsonResponseToXlsxTest extends TestCase
 
         $response = new TestResponse($this->getUnwrappedResponse()->toXlsx('filename.xlsx'));
 
-        $this->assertEquals("attachment; filename=\"filename.xlsx\"; filename*=utf-8''filename.xlsx", $response->headers->get('Content-Disposition'));
+        $this->assertEquals('attachment; filename=filename.xlsx', $response->headers->get('Content-Disposition'));
 
         $reader = $this->getExcelReader($response->streamedContent());
         $headers = $reader->getHeaders();
@@ -45,7 +45,7 @@ class JsonResponseToXlsxTest extends TestCase
 
         $response = new TestResponse($this->getWrappedResponse()->toXlsx('filename.xlsx', 'data'));
 
-        $this->assertEquals("attachment; filename=\"filename.xlsx\"; filename*=utf-8''filename.xlsx", $response->headers->get('Content-Disposition'));
+        $this->assertEquals('attachment; filename=filename.xlsx', $response->headers->get('Content-Disposition'));
 
         $reader = $this->getExcelReader($response->streamedContent());
         $headers = $reader->getHeaders();

--- a/tests/Unit/JsonResponseToXmlTest.php
+++ b/tests/Unit/JsonResponseToXmlTest.php
@@ -16,7 +16,7 @@ class JsonResponseToXmlTest extends TestCase
 
         $response = $this->getUnwrappedResponse()->toXml('filename.xml');
 
-        $this->assertEquals("attachment; filename=\"filename.xml\"; filename*=utf-8''filename.xml", $response->headers->get('Content-Disposition'));
+        $this->assertEquals('attachment; filename=filename.xml', $response->headers->get('Content-Disposition'));
         $this->assertEquals('<?xml version="1.0"?>
 <root><data><id>1</id><name>Navn</name><data><foo>bar</foo></data><meta/></data><data><id>2</id><name>Noe annet</name><data><foo>bar</foo><bar>foo</bar></data></data></root>
 ', $response->getContent());
@@ -29,7 +29,7 @@ class JsonResponseToXmlTest extends TestCase
 
         $response = $this->getWrappedResponse()->toXml('filename.xml');
 
-        $this->assertEquals("attachment; filename=\"filename.xml\"; filename*=utf-8''filename.xml", $response->headers->get('Content-Disposition'));
+        $this->assertEquals('attachment; filename=filename.xml', $response->headers->get('Content-Disposition'));
         $this->assertEquals('<?xml version="1.0"?>
 <root><data><id>1</id><name>Navn</name><data><foo>bar</foo></data><meta/></data><data><id>2</id><name>Noe annet</name><data><foo>bar</foo><bar>foo</bar></data></data><meta><page>1</page></meta></root>
 ', $response->getContent());
@@ -42,7 +42,7 @@ class JsonResponseToXmlTest extends TestCase
 
         $response = $this->getWrappedResponse()->toXml('filename.xml', 'data');
 
-        $this->assertEquals("attachment; filename=\"filename.xml\"; filename*=utf-8''filename.xml", $response->headers->get('Content-Disposition'));
+        $this->assertEquals('attachment; filename=filename.xml', $response->headers->get('Content-Disposition'));
         $this->assertEquals('<?xml version="1.0"?>
 <root><data><id>1</id><name>Navn</name><data><foo>bar</foo></data><meta/></data><data><id>2</id><name>Noe annet</name><data><foo>bar</foo><bar>foo</bar></data></data></root>
 ', $response->getContent());


### PR DESCRIPTION
## Summary

- `Macros/Response/Filename.php` was building the `Content-Disposition` header by hand with `sprintf`, interpolating the filename raw into a quoted value — a double-quote or CRLF in the filename broke out of the header
- Replaced with `Symfony\Component\HttpFoundation\HeaderUtils::makeDisposition()` (the same helper Laravel uses for file downloads), which safely escapes all injection characters
- Added automatic `Str::ascii()` fallback derivation so a single non-ASCII filename argument never throws and still produces a valid `filename*=utf-8''…` parameter — full UTF-8 support is retained
- The two-argument `->filename($ascii, $utf8)` calling convention is preserved unchanged

## Header format change

For ASCII filenames the emitted header changes from the redundant (but harmless) double form to the RFC-6266-correct single form:

```
# before
attachment; filename="documents.csv"; filename*=utf-8''documents.csv

# after
attachment; filename=documents.csv

# non-ASCII (unchanged semantics, quotes dropped from fallback)
attachment; filename=AEOEAA.csv; filename*=utf-8''%C3%86%C3%98%C3%85.csv
```

## Test plan

- [ ] `test_it_neutralizes_double_quote_injection_in_filename` — `->filename('a"b.csv')` produces an escaped, injection-free header with no CR/LF
- [ ] `test_it_derives_ascii_fallback_for_single_non_ascii_filename` — `->filename('ÆØÅ.csv')` produces a valid `filename*` header without throwing
- [ ] All 29 existing tests pass with updated assertions
- [ ] `composer verify` passes (Pint + phpmd + phpunit)